### PR TITLE
Undefined variables

### DIFF
--- a/js/adapt-textWithPopup.js
+++ b/js/adapt-textWithPopup.js
@@ -58,8 +58,8 @@ define([
 
       event && event.preventDefault();
 
-      var currentPopup = event.target;
-      popupItems = this.model.get('_items');
+      var currentPopup = event.target,
+      popupItems = this.model.get('_items'),
       popupObject = {};
 
       popupItems.forEach(function(current){


### PR DESCRIPTION
Added commas to declare the variables.  When working in the framework as opposed to the authoring tool, an undefined error is thrown.